### PR TITLE
Silence prawn-svg :enable_web_requests deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.7.4 (2026-08-13)
+
+* Pass `enable_web_requests: false` when rendering SVG logos. Logos are read from local files, so nothing needs fetching over the network. This silences prawn-svg's deprecation warning and keeps behaviour stable when prawn-svg 1.0 flips the default to `false`.
+
 ## 1.7.3 (2026-02-16)
 
 * Add retention support (e.g. Spanish IRPF). Set `retention_rate` on an invoice to apply a post-tax deduction calculated as a percentage of the subtotal. The retention amount is displayed as a negative line in the PDF and subtracted from the total. Customize the label with `retention_description` or via the `payday.invoice.retention` i18n key.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webtranslateit-payday (1.7.3)
+    webtranslateit-payday (1.7.4)
       activesupport (>= 7, < 9)
       i18n (~> 1.12, < 2)
       money (>= 6.16, < 8.0)
@@ -41,6 +41,17 @@ GEM
     diff-lcs (1.6.2)
     drb (2.2.3)
     ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-aarch64-mingw-ucrt)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     formatador (1.2.3)
       reline
     guard (2.20.2)
@@ -196,4 +207,4 @@ DEPENDENCIES
   webtranslateit-payday!
 
 BUNDLED WITH
-   2.6.2
+   4.0.18

--- a/lib/payday/pdf_renderer.rb
+++ b/lib/payday/pdf_renderer.rb
@@ -80,7 +80,11 @@ module Payday
       end
 
       if File.extname(image) == '.svg'
-        logo_info = pdf.svg(File.read(image), at: pdf.bounds.top_left, width: width, height: height)
+        # Logos are read from local files, so there is nothing to fetch over the network.
+        # Passing this explicitly also silences prawn-svg's deprecation warning and keeps
+        # behaviour stable when prawn-svg 1.0 flips the default to false.
+        logo_info = pdf.svg(File.read(image), at: pdf.bounds.top_left, width: width, height: height,
+                                              enable_web_requests: false)
         logo_height = logo_info[:height]
       else
         logo_info = pdf.image(image, at: pdf.bounds.top_left, width: width, height: height)

--- a/payday.gemspec
+++ b/payday.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'webtranslateit-payday'
-  s.version     = '1.7.3'
+  s.version     = '1.7.4'
   s.required_ruby_version = '>= 3.2'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Alan Johnson', 'Edouard Briere']


### PR DESCRIPTION
Fixes the prawn-svg warning reported in webtranslateit/webtranslateit.com#7188:

```
[prawn-svg] WARNING: :enable_web_requests is not set and currently defaults to true. In prawn-svg 1.0, this will default to false.
```

Invoice logos are read from local files (`File.read(image)`), so there is nothing to fetch over the network. Passing `enable_web_requests: false` explicitly silences the warning and keeps behaviour stable when prawn-svg 1.0 flips the default — it also avoids prawn-svg fetching arbitrary remote URLs referenced from a logo SVG.

Bumped to 1.7.4 with a CHANGELOG entry so the app can pick it up.

Verified: the warning is emitted by the existing suite before the change (the SVG path is covered via `spec/assets/tiger.svg`) and gone after. 37 examples, 0 failures; rubocop clean.